### PR TITLE
Fix bug not properly deleting entries during cleanup #2

### DIFF
--- a/certbot_dns_hetzner/dns_hetzner.py
+++ b/certbot_dns_hetzner/dns_hetzner.py
@@ -74,8 +74,8 @@ class Authenticator(dns_common.DNSAuthenticator):
             self.credentials.conf('api_token'),
         )
 
-    def _fqdn_format(self, name):
+    @staticmethod
+    def _fqdn_format(name):
         if not name.endswith('.'):
             return '{0}.'.format(name)
-        else:
-            return name
+        return name

--- a/certbot_dns_hetzner/dns_hetzner_test.py
+++ b/certbot_dns_hetzner/dns_hetzner_test.py
@@ -50,7 +50,6 @@ class AuthenticatorTest(
         self.mock_client.add_record.assert_called_with(
             DOMAIN, 'TXT', '_acme-challenge.' + DOMAIN + '.', mock.ANY, mock.ANY
         )
-        self.assertEqual(self.auth.record_id, FAKE_RECORD['record']['id'])
 
     def test_perform_but_raises_zone_not_found(self):
         self.mock_client.add_record.side_effect = mock.MagicMock(side_effect=_ZoneNotFoundException(DOMAIN))
@@ -69,7 +68,7 @@ class AuthenticatorTest(
         self.auth._attempt_cleanup = True
         self.auth.cleanup([self.achall])
 
-        self.mock_client.delete_record.assert_called_with(record_id=FAKE_RECORD['record']['id'])
+        self.mock_client.delete_record_by_name.assert_called_with(DOMAIN, '_acme-challenge.' + DOMAIN + '.')
 
 
 if __name__ == '__main__':

--- a/certbot_dns_hetzner/dns_hetzner_test.py
+++ b/certbot_dns_hetzner/dns_hetzner_test.py
@@ -70,6 +70,15 @@ class AuthenticatorTest(
 
         self.mock_client.delete_record_by_name.assert_called_with(DOMAIN, '_acme-challenge.' + DOMAIN + '.')
 
+    def test_cleanup_but_connection_aborts(self):
+        self.mock_client.add_record.return_value = FAKE_RECORD
+        # _attempt_cleanup | pylint: disable=protected-access
+        self.auth.perform([self.achall])
+        self.auth._attempt_cleanup = True
+        self.auth.cleanup([self.achall])
+
+        self.mock_client.delete_record_by_name.assert_called_with(DOMAIN, '_acme-challenge.' + DOMAIN + '.')
+
 
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover

--- a/certbot_dns_hetzner/fakes.py
+++ b/certbot_dns_hetzner/fakes.py
@@ -12,12 +12,31 @@ FAKE_RECORD = {
 FAKE_DOMAIN = 'some.domain'
 FAKE_ZONE_ID = 'xyz'
 FAKE_RECORD_ID = 'zzz'
+FAKE_RECORD_NAME = 'thisisarecordname'
 
 FAKE_RECORD_RESPONSE = {
     "record": {
         "id": FAKE_RECORD_ID,
         "name": "string",
     }
+}
+
+FAKE_RECORDS_RESPONSE_WITH_RECORD = {
+    "records": [
+        {
+            "id": FAKE_RECORD_ID,
+            "name": FAKE_RECORD_NAME,
+        }
+    ]
+}
+
+FAKE_RECORDS_RESPONSE_WITHOUT_RECORD = {
+    "records": [
+        {
+            "id": 'nottheoneuwant',
+            "name": "string",
+        }
+    ]
 }
 
 FAKE_ZONES_RESPONSE_WITH_DOMAIN = {

--- a/certbot_dns_hetzner/hetzner_client.py
+++ b/certbot_dns_hetzner/hetzner_client.py
@@ -88,6 +88,22 @@ class _HetznerClient:
         except (ValueError, UnicodeDecodeError) as exception:
             raise _MalformedResponseException(exception)
 
+    def delete_record_by_name(self, domain, record_name):
+        """
+        Searches for a zone matching ``domain``, if found find and delete a record matching ``record_name`
+        Deletes record with ``record_id`` from your Hetzner Account
+        :param domain: Domain of zone in which the record should be found
+        :param record_name: ID of record to be deleted
+        :raises requests.exceptions.ConnectionError: If the API request fails
+        :raises ._MalformedResponseException: If the API response is not 200
+        :raises ._ZoneNotFoundException: If no zone is found matching ``domain``
+        :raises ._RecordNotFoundException: If no record is found matching ``record_name``
+        :raises ._NotAuthorizedException: If Hetzner does not accept the authorization credentials
+        """
+        zone_id = self._get_zone_id_by_domain(domain)
+        record_id = self._get_record_id_by_name(zone_id, record_name)
+        self.delete_record(record_id)
+
     def delete_record(self, record_id):
         """
         Deletes record with ``record_id`` from your Hetzner Account

--- a/certbot_dns_hetzner/hetzner_client_test.py
+++ b/certbot_dns_hetzner/hetzner_client_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0212
 """
 Test suite for _HetznerClient
 """
@@ -7,9 +8,10 @@ import requests
 import requests_mock
 
 from certbot_dns_hetzner.fakes import FAKE_API_TOKEN, FAKE_RECORD_RESPONSE, FAKE_DOMAIN, \
-    FAKE_ZONES_RESPONSE_WITH_DOMAIN, FAKE_ZONES_RESPONSE_WITHOUT_DOMAIN, FAKE_RECORD_ID
+    FAKE_ZONES_RESPONSE_WITH_DOMAIN, FAKE_ZONES_RESPONSE_WITHOUT_DOMAIN, FAKE_RECORD_ID, FAKE_ZONE_ID, \
+    FAKE_RECORDS_RESPONSE_WITH_RECORD, FAKE_RECORD_NAME, FAKE_RECORDS_RESPONSE_WITHOUT_RECORD
 from certbot_dns_hetzner.hetzner_client import HETZNER_API_ENDPOINT, _ZoneNotFoundException, \
-    _MalformedResponseException, _NotAuthorizedException
+    _MalformedResponseException, _NotAuthorizedException, _RecordNotFoundException
 
 
 class HetznerClientTest(unittest.TestCase):
@@ -20,6 +22,20 @@ class HetznerClientTest(unittest.TestCase):
     def setUp(self):
         from certbot_dns_hetzner.dns_hetzner import _HetznerClient  # pylint: disable=import-outside-toplevel
         self.client = _HetznerClient(FAKE_API_TOKEN)
+
+    def test_get_zone_by_name(self):
+        with requests_mock.Mocker() as mock:
+            mock.get('{0}/zones'.format(HETZNER_API_ENDPOINT), status_code=200, json=FAKE_ZONES_RESPONSE_WITH_DOMAIN)
+            zone_id = self.client._get_zone_id_by_domain(FAKE_DOMAIN)
+            self.assertEqual(zone_id, FAKE_ZONE_ID)
+
+    def test_get_zone_by_name_but_zone_response_is_garbage(self):
+        with requests_mock.Mocker() as mock:
+            mock.get('{0}/zones'.format(HETZNER_API_ENDPOINT), status_code=200, text='garbage')
+            self.assertRaises(
+                _MalformedResponseException,
+                self.client._get_zone_id_by_domain, FAKE_DOMAIN
+            )
 
     def test_add_record(self):
         with requests_mock.Mocker() as mock:
@@ -43,6 +59,14 @@ class HetznerClientTest(unittest.TestCase):
             mock.post('{0}/records'.format(HETZNER_API_ENDPOINT), status_code=406)
             self.assertRaises(
                 _MalformedResponseException,
+                self.client.add_record, FAKE_DOMAIN, "TXT", "somename", "somevalue", 42
+            )
+
+    def test_add_record_but_record_but_unauthorized(self):
+        with requests_mock.Mocker() as mock:
+            mock.get('{0}/zones'.format(HETZNER_API_ENDPOINT), status_code=401)
+            self.assertRaises(
+                _NotAuthorizedException,
                 self.client.add_record, FAKE_DOMAIN, "TXT", "somename", "somevalue", 42
             )
 
@@ -83,4 +107,34 @@ class HetznerClientTest(unittest.TestCase):
             self.assertRaises(
                 _MalformedResponseException,
                 self.client.delete_record, FAKE_RECORD_ID
+            )
+
+    def test_delete_record_by_name_and_found(self):
+        with requests_mock.Mocker() as mock:
+            mock.get('{0}/zones'.format(HETZNER_API_ENDPOINT), status_code=200, json=FAKE_ZONES_RESPONSE_WITH_DOMAIN)
+            mock.get('{0}/records?zone_id={1}'.format(
+                HETZNER_API_ENDPOINT,
+                FAKE_ZONE_ID
+            ), status_code=200, json=FAKE_RECORDS_RESPONSE_WITH_RECORD)
+            mock.delete('{0}/records/{1}'.format(HETZNER_API_ENDPOINT, FAKE_RECORD_ID), status_code=200)
+            self.client.delete_record_by_name(FAKE_DOMAIN, FAKE_RECORD_NAME)
+
+    def test_delete_record_by_name_but_its_not_found(self):
+        with requests_mock.Mocker() as mock:
+            mock.get('{0}/zones'.format(HETZNER_API_ENDPOINT), status_code=200, json=FAKE_ZONES_RESPONSE_WITH_DOMAIN)
+            mock.get('{0}/records?zone_id={1}'.format(
+                HETZNER_API_ENDPOINT,
+                FAKE_ZONE_ID
+            ), status_code=200, json=FAKE_RECORDS_RESPONSE_WITHOUT_RECORD)
+            self.assertRaises(
+                _RecordNotFoundException,
+                self.client.delete_record_by_name, FAKE_DOMAIN, FAKE_RECORD_NAME
+            )
+
+    def test_delete_record_by_name_but_zone_is_not_found(self):
+        with requests_mock.Mocker() as mock:
+            mock.get('{0}/zones'.format(HETZNER_API_ENDPOINT), status_code=200, json=FAKE_ZONES_RESPONSE_WITHOUT_DOMAIN)
+            self.assertRaises(
+                _ZoneNotFoundException,
+                self.client.delete_record_by_name, FAKE_DOMAIN, FAKE_RECORD_NAME
             )


### PR DESCRIPTION
Turns out a stateful authenticator can lead to problems. In this case
having multiple domains to challenge would overwrite record_id,
meaning that during cleanup only one id will actually be deleting.

We are now resorting to a stateless call with only domain name and record name.
We resolve the correct record id by iterating hetzners responses.

Fixes #2 