### PR TITLE
Pin parsedatetime version only for Python < 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'requests',
     'mock',
     'requests-mock',
-    'parsedatetime<=2.5'
+    'parsedatetime<=2.5;python_version<"3.0"'
 ]
 
 BASE_PATH = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
certbot-dns-hetzner fails on a lot of platforms since the parsedatetime
update to version 2.6, needlessly. So lets enforce parsedatetime 2.5
only for Python 2.

https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#platform-specific-dependencies

Fixes #9