### PR TITLE
Remove zope dependency

### DIFF
--- a/certbot_dns_hetzner/dns_hetzner.py
+++ b/certbot_dns_hetzner/dns_hetzner.py
@@ -1,10 +1,8 @@
 """DNS Authenticator for Hetzner DNS."""
 import requests
 
-import zope.interface
 
 from certbot import errors
-from certbot import interfaces
 from certbot.plugins import dns_common
 
 from certbot_dns_hetzner.hetzner_client import \
@@ -15,8 +13,6 @@ from certbot_dns_hetzner.hetzner_client import \
 TTL = 60
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for Hetzner
     This Authenticator uses the Hetzner DNS API to fulfill a dns-01 challenge.

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,8 @@ version = '1.0.5'
 # specified here to avoid masking the more specific request requirements in
 # acme. See https://github.com/pypa/pip/issues/988 for more info.
 install_requires = [
-    'certbot>=1.1.0',
+    'certbot>=2.0.0',
     'setuptools',
-    'zope.interface',
     'requests',
     'requests-mock',
     'parsedatetime<=2.5;python_version<"3.0"'


### PR DESCRIPTION
Release [2.0.0 of certbot] removed the zope based interfaces.

[2.0.0 of certbot]: https://github.com/certbot/certbot/releases/tag/v2.0.0