### PR TITLE
Use dns-lexicon's Client instead of deprecated providers

### DIFF
--- a/certbot_dns_hetzner/dns_hetzner.py
+++ b/certbot_dns_hetzner/dns_hetzner.py
@@ -48,10 +48,12 @@ class Authenticator(dns_common.DNSAuthenticator):
         return '.'.join([zone_name.domain, zone_name.suffix])
 
     def _perform(self, domain, validation_name, validation):
-        self._get_hetzner_client(domain).create_record("TXT", self._fqdn_format(validation_name), validation)
+        with self._get_hetzner_client(domain) as client:
+            client.create_record("TXT", self._fqdn_format(validation_name), validation)
 
     def _cleanup(self, domain, validation_name, validation):
-        self._get_hetzner_client(domain).delete_record(None, "TXT", self._fqdn_format(validation_name), validation)
+        with self._get_hetzner_client(domain) as client:
+            client.delete_record(None, "TXT", self._fqdn_format(validation_name), validation)
 
     def _get_hetzner_client(self, domain):
         config = ConfigResolver().with_env().with_dict({

--- a/certbot_dns_hetzner/dns_hetzner.py
+++ b/certbot_dns_hetzner/dns_hetzner.py
@@ -48,12 +48,10 @@ class Authenticator(dns_common.DNSAuthenticator):
         return '.'.join([zone_name.domain, zone_name.suffix])
 
     def _perform(self, domain, validation_name, validation):
-        with self._get_hetzner_client(domain) as client:
-            client.create_record("TXT", validation_name, validation)
+        self._get_hetzner_client(domain).create_record("TXT", self._fqdn_format(validation_name), validation)
 
     def _cleanup(self, domain, validation_name, validation):
-        with self._get_hetzner_client(domain) as client:
-            client.delete_record(None, "TXT", validation_name, validation)
+        self._get_hetzner_client(domain).delete_record(None, "TXT", self._fqdn_format(validation_name), validation)
 
     def _get_hetzner_client(self, domain):
         config = ConfigResolver().with_env().with_dict({

--- a/certbot_dns_hetzner/dns_hetzner_test.py
+++ b/certbot_dns_hetzner/dns_hetzner_test.py
@@ -43,9 +43,16 @@ class AuthenticatorTest(
         self.auth = Authenticator(self.config, "hetzner")
 
         self.mock_client = mock.MagicMock()
+
+        mock_client_wrapper = mock.MagicMock()
+        mock_client_wrapper.__enter__ = mock.MagicMock(
+            return_value=self.mock_client
+        )
+
         # _get_ispconfig_client | pylint: disable=protected-access
         self.auth._get_hetzner_client = mock.MagicMock(
-            return_value=self.mock_client)
+            return_value=mock_client_wrapper
+        )
 
     @patch_display_util()
     def test_perform(self, _unused_mock_get_utility):

--- a/certbot_dns_hetzner/dns_hetzner_test.py
+++ b/certbot_dns_hetzner/dns_hetzner_test.py
@@ -48,7 +48,7 @@ class AuthenticatorTest(
             return_value=self.mock_client)
 
     @patch_display_util()
-    def test_perform(self, unused_mock_get_utility):
+    def test_perform(self, _unused_mock_get_utility):
         self.mock_client.create_record.return_value = FAKE_RECORD
         self.auth.perform([self.achall])
         self.mock_client.create_record.assert_called_with(
@@ -65,7 +65,7 @@ class AuthenticatorTest(
         )
 
     @patch_display_util()
-    def test_cleanup(self, unused_mock_get_utility):
+    def test_cleanup(self, _unused_mock_get_utility):
         self.mock_client.create_record.return_value = FAKE_RECORD
         # _attempt_cleanup | pylint: disable=protected-access
         self.auth.perform([self.achall])
@@ -77,7 +77,7 @@ class AuthenticatorTest(
         )
 
     @patch_display_util()
-    def test_cleanup_but_raises_plugin_error(self, unused_mock_get_utility):
+    def test_cleanup_but_raises_plugin_error(self, _unused_mock_get_utility):
         self.mock_client.create_record.return_value = FAKE_RECORD
         self.mock_client.delete_record.side_effect = mock.MagicMock(
             side_effect=PluginError()

--- a/certbot_dns_hetzner/dns_hetzner_test.py
+++ b/certbot_dns_hetzner/dns_hetzner_test.py
@@ -13,7 +13,6 @@ from certbot.tests import util as test_util
 from certbot_dns_hetzner.fakes import FAKE_API_TOKEN, FAKE_RECORD
 
 
-
 patch_display_util = test_util.patch_display_util
 
 
@@ -50,37 +49,37 @@ class AuthenticatorTest(
 
     @patch_display_util()
     def test_perform(self, unused_mock_get_utility):
-        self.mock_client.add_txt_record.return_value = FAKE_RECORD
+        self.mock_client.create_record.return_value = FAKE_RECORD
         self.auth.perform([self.achall])
-        self.mock_client.add_txt_record.assert_called_with(
-            DOMAIN, "_acme-challenge." + DOMAIN + ".", mock.ANY
+        self.mock_client.create_record.assert_called_with(
+            "TXT", "_acme-challenge." + DOMAIN + ".", mock.ANY
         )
 
     def test_perform_but_raises_plugin_error(self):
-        self.mock_client.add_txt_record.side_effect = mock.MagicMock(
+        self.mock_client.create_record.side_effect = mock.MagicMock(
             side_effect=PluginError()
         )
         self.assertRaises(PluginError, self.auth.perform, [self.achall])
-        self.mock_client.add_txt_record.assert_called_with(
-            DOMAIN, "_acme-challenge." + DOMAIN + ".", mock.ANY
+        self.mock_client.create_record.assert_called_with(
+            "TXT", "_acme-challenge." + DOMAIN + ".", mock.ANY
         )
 
     @patch_display_util()
     def test_cleanup(self, unused_mock_get_utility):
-        self.mock_client.add_txt_record.return_value = FAKE_RECORD
+        self.mock_client.create_record.return_value = FAKE_RECORD
         # _attempt_cleanup | pylint: disable=protected-access
         self.auth.perform([self.achall])
         self.auth._attempt_cleanup = True
         self.auth.cleanup([self.achall])
 
-        self.mock_client.del_txt_record.assert_called_with(
-            DOMAIN, "_acme-challenge." + DOMAIN + ".", mock.ANY
+        self.mock_client.delete_record.assert_called_with(
+            None, "TXT", "_acme-challenge." + DOMAIN + ".", mock.ANY
         )
 
     @patch_display_util()
     def test_cleanup_but_raises_plugin_error(self, unused_mock_get_utility):
-        self.mock_client.add_txt_record.return_value = FAKE_RECORD
-        self.mock_client.del_txt_record.side_effect = mock.MagicMock(
+        self.mock_client.create_record.return_value = FAKE_RECORD
+        self.mock_client.delete_record.side_effect = mock.MagicMock(
             side_effect=PluginError()
         )
         # _attempt_cleanup | pylint: disable=protected-access
@@ -88,8 +87,8 @@ class AuthenticatorTest(
         self.auth._attempt_cleanup = True
 
         self.assertRaises(PluginError, self.auth.cleanup, [self.achall])
-        self.mock_client.del_txt_record.assert_called_with(
-            DOMAIN, "_acme-challenge." + DOMAIN + ".", mock.ANY
+        self.mock_client.delete_record.assert_called_with(
+            None, "TXT", "_acme-challenge." + DOMAIN + ".", mock.ANY
         )
 
 


### PR DESCRIPTION
`lexicon.providers.*` is deprecated and it is suggested to use `lexicon.client.Client` instead.  
Therefore I tried to implement the new approach.  